### PR TITLE
Test on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+sudo: false
+language: python
+python: ## Keep in sync with `tox.ini`
+  - 2.7
+  - 3.2
+  - 3.3
+  - 3.4
+install:
+  - pip install -r requirements.txt
+  - npm install -g uglify-js less
+before_script:
+  - case $(python -c 'import sys; print (sys.version_info.major)') in 2) ;; 3) 2to3 -w learning_greek/settings.py;; esac ## For `urlparse`.
+  - psql -c 'create database travis_ci_test;' -U postgres
+  - ./refresh.sh ## PGUSER=postgres ## Ref https://docs.travis-ci.com/user/using-postgresql/#Using-PostgreSQL-in-your-Builds
+script:
+  - (cd learning_greek/static/learning_greek/; make)
+  - ./manage.py runserver &
+  - S=$!
+  - sleep 10 ## HACK Just to be reasonably sure DB and Web Server are up...
+  - curl http://127.0.0.1:8000/ | tee >(cat 1>&2) | grep 'Code available under an MIT License. Content available under a CC-BY-SA license unless otherwise noted.' ## Assumption: bash. Ref https://docs.travis-ci.com/user/customizing-the-build/#How-does-this-work%3F-(Or%2C-why-you-should-not-use-exit-in-build-steps)
+  - kill $S
+matrix:
+  allow_failures:
+    - python: 3.2
+  fast_finish: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # learning-greek
 
 [![Join the chat at https://gitter.im/jtauber/learning-greek](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/jtauber/learning-greek?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/jtauber/learning-greek.svg)](https://travis-ci.org/jtauber/learning-greek)
 
 I’m building this site partly to help people learn Koine Greek and partly to
 research how to improve the way people learn Koine Greek.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ eventlog==0.9.0
 django-jsonfield==0.9.13
 
 # pinax-blog==3.1.3
-pinax-lms-activities==0.2.0
+-e git+https://github.com/pinax/pinax-lms-activities/@0518744d78e90cdca36d7b768a5448777b2231aa#egg=pinax_lms_activities-master
 
 gondor==1.2.5
 gunicorn==19.1.1


### PR DESCRIPTION
In order to enable Travis CI builds on your repository, merging this PR is not enough. Please refer to http://docs.travis-ci.com/user/getting-started/

As described in the commit message, this basic test shows an issue with Python 3.2. Please consider either dropping support for Python 3.2 or upgrading dependency `pinax-theme-bootstrap` to version >= 6.1.0 (PR #29 already proposes that).

Depends on PR #30.

BTW It looks like PR #29 would also simplify Travis CI setup (`npm install` not needed anymore?).
